### PR TITLE
pass indices to child nodes

### DIFF
--- a/run_string_example.py
+++ b/run_string_example.py
@@ -1,0 +1,14 @@
+import numpy as np
+import src.problemgenerator.array as array
+import src.problemgenerator.filters as filters
+import src.problemgenerator.copy as copy
+
+data = np.array(["hello world",
+                 "all your Bayes' theorems are belong to us"])
+
+x_node = array.Array(data.shape)
+x_node.addfilter(filters.Uppercase(.45))
+root_node = copy.Copy(x_node)
+out = root_node.process(data)
+print(out)
+print("output shape:", out.shape, ", output dtype:", out.dtype)

--- a/src/problemgenerator/array.py
+++ b/src/problemgenerator/array.py
@@ -8,6 +8,6 @@ class Array:
         self.filters.append(custom_filter)
         custom_filter.shape = self.shape
 
-    def process(self, input_source):
+    def process(self, data, index_tuple=()):
         for f in self.filters:
-            f.apply(input_source)
+            f.apply(data, (index_tuple))

--- a/src/problemgenerator/filters.py
+++ b/src/problemgenerator/filters.py
@@ -5,6 +5,7 @@ class Filter:
 
     def __init__(self):
         np.random.seed(42)
+        self.shape = ()
 
 
 class Missing(Filter):
@@ -13,11 +14,11 @@ class Missing(Filter):
         self.probability = probability
         super().__init__()
 
-    def apply(self, data):
+    def apply(self, data, index_tuple):
         mask = np.random.choice([True, False],
-                                size=data.shape,
+                                size=data[index_tuple].shape,
                                 p=[self.probability, 1. - self.probability])
-        data[mask] = np.nan
+        data[index_tuple][mask] = np.nan
 
 
 class GaussianNoise(Filter):
@@ -26,5 +27,25 @@ class GaussianNoise(Filter):
         self.std = std
         super().__init__()
 
-    def apply(self, data):
-        data += np.random.normal(loc=self.mean, scale=self.std, size=data.shape)
+    def apply(self, data, index_tuple):
+        data[index_tuple] += np.random.normal(loc=self.mean,
+                                              scale=self.std,
+                                              size=data[index_tuple].shape)
+
+class Uppercase(Filter):
+
+    def __init__(self, probability):
+        self.prob = probability
+        super().__init__()
+
+    def apply(self, data, index_tuple):
+
+        def stochastic_upper(char, probability):
+            if np.random.binomial(1, probability):
+                return char.upper()
+            return char
+
+        for index, element in np.ndenumerate(data[index_tuple]):
+            original_string = element
+            modified_string = "".join([stochastic_upper(c, self.prob) for c in original_string])
+            data[index_tuple][index] = modified_string

--- a/src/problemgenerator/series.py
+++ b/src/problemgenerator/series.py
@@ -3,10 +3,10 @@ class Series:
     def __init__(self, child):
         self.child = child
 
-    def process(self, data):
-        data_length = data.shape[0]
+    def process(self, data, index_tuple=()):
+        data_length = data[index_tuple].shape[0]
         for i in range(data_length):
-            self.child.process(data[i, ...])
+            self.child.process(data, (i, *index_tuple))
 
 class TupleSeries:
 
@@ -17,4 +17,4 @@ class TupleSeries:
         data_length = data[0].shape[0]
         for i, child in enumerate(self.children):
             for j in range(data_length):
-                child.process(data[i][j, ...])
+                child.process(data[i], (j,))


### PR DESCRIPTION
In this improved version of the tree model, nodes no longer pass down slices of the data they receive from their parent. Instead they pass down a reference to the entire data object and an index tuple indicating the slice of the data upon which the node should operate. This way we can apply errors in-place even when the data type is immutable (e.g. string).