### PR TITLE
Debug rotation

### DIFF
--- a/dpemu/filters/image.py
+++ b/dpemu/filters/image.py
@@ -76,7 +76,7 @@ class Resolution(Filter):
 
 
 class Rotation(Filter):
-    """Rotates the filter.
+    """Rotates the image.
 
     If only min_angle is provided, the the image is rotated according to the angle.
     If both min_angle and max_angle are provided, then the rotation angle is chosen

--- a/dpemu/problemgenerator/array.py
+++ b/dpemu/problemgenerator/array.py
@@ -8,6 +8,11 @@ class Array(LeafNode):
     One or more filters (error sources) can be added to the node.
     The filters are applied in the order in which they are added.
 
+    You can optionally provide the constructor with a reshape parameter.
+    In that case the filters attached to the node operate on data
+    reshaped to the desired shape. The final shape of the data is
+    unaffected.
+
     Constructor Args:
         reshape (tuple, optional): The data shape required by the
             node's filters if different from the actual shape of

--- a/dpemu/problemgenerator/array.py
+++ b/dpemu/problemgenerator/array.py
@@ -12,8 +12,9 @@ class Array(LeafNode):
         Node (object):
     """
 
-    def __init__(self):
+    def __init__(self, reshape=None):
         super().__init__()
+        self.reshape = reshape
 
     def apply_filters(self, node_data, random_state, named_dims):
         """Apply filters to data contained in this array.
@@ -24,7 +25,13 @@ class Array(LeafNode):
             named_dims (dict): Named dimensions.
         """
         for f in self.filters:
-            f.apply(node_data, random_state, named_dims)
+            if self.reshape:
+                original_shape = node_data.shape
+                temp_data = node_data.reshape(self.reshape)
+                f.apply(temp_data, random_state, named_dims)
+                node_data[...] = temp_data.reshape(original_shape)
+            else:
+                f.apply(node_data, random_state, named_dims)
 
     def process(self, data, random_state, index_tuple=(), named_dims={}):
         """Apply all filters in this node.

--- a/dpemu/problemgenerator/array.py
+++ b/dpemu/problemgenerator/array.py
@@ -8,8 +8,10 @@ class Array(LeafNode):
     One or more filters (error sources) can be added to the node.
     The filters are applied in the order in which they are added.
 
-    Args:
-        Node (object):
+    Constructor Args:
+        reshape (tuple, optional): The data shape required by the
+            node's filters if different from the actual shape of
+            the data
     """
 
     def __init__(self, reshape=None):

--- a/examples/run_rotate_MNIST_example.py
+++ b/examples/run_rotate_MNIST_example.py
@@ -1,0 +1,29 @@
+import sys
+import matplotlib.pyplot as plt
+
+from dpemu.nodes import Array, Series
+from dpemu.filters.image import Rotation
+from dpemu.dataset_utils import load_mnist
+
+
+def main():
+    """An example that rotates MNIST digits and displays one.
+    Usage: python run_rotate_MNIST_example <angle>
+    where <angle> is the angle of rotation
+    (e.g. 90 to rotate by pi / 2)
+    """
+    x, y, _, _ = load_mnist()
+    xs = x[:20]                 # small subset of x
+    angle = float(sys.argv[1])
+    print(xs.shape)
+    img_node = Array(reshape=(28, 28))
+    root_node = Series(img_node)
+    img_node.addfilter(Rotation("angle"))
+    result = root_node.generate_error(xs, {'angle': angle})
+
+    plt.matshow(result[0].reshape((28, 28)))
+    plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/run_rotate_MNIST_example.py
+++ b/examples/run_rotate_MNIST_example.py
@@ -12,7 +12,7 @@ def main():
     where <angle> is the angle of rotation
     (e.g. 90 to rotate by pi / 2)
     """
-    x, y, _, _ = load_mnist()
+    x, _, _, _ = load_mnist()
     xs = x[:20]                 # small subset of x
     angle = float(sys.argv[1])
     print(xs.shape)


### PR DESCRIPTION
Array nodes now take an optional reshape parameter. If the parameter is provided, the filters are applied to reshaped data, but the final shape of the data is unaffected.

An example script is provided where MNIST digits are rotated using the Rotate filter.