### PR TITLE
Example imports

### DIFF
--- a/dpemu/dataset_utils.py
+++ b/dpemu/dataset_utils.py
@@ -88,9 +88,9 @@ def load_mnist(n_data=70000):
 
 def _load_mnist(reshape_to_28x28=False):
     (x_train, y_train), (x_test, y_test) = load_mnist_data()
-    if reshape_to_28x28:
-        x_train = x_train.reshape((-1, 28, 28))
-        x_test = x_test.reshape((-1, 28, 28))
+    if not reshape_to_28x28:
+        x_train = x_train.reshape((-1, 28*28))
+        x_test = x_test.reshape((-1, 28*28))
     return x_train, y_train, x_test, y_test
 
 def load_fashion(n_data=70000):

--- a/dpemu/dataset_utils.py
+++ b/dpemu/dataset_utils.py
@@ -20,6 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import warnings
 import os
 import random as rn
 from subprocess import Popen
@@ -31,6 +32,9 @@ from sklearn.datasets import fetch_20newsgroups, fetch_openml, load_digits
 from sklearn.model_selection import train_test_split
 
 from dpemu.utils import get_project_root
+
+warnings.simplefilter(action='ignore', category=FutureWarning)
+from keras.datasets.mnist import load_data as load_mnist_data
 
 random_state = RandomState(42)
 
@@ -81,6 +85,13 @@ def load_mnist(n_data=70000):
     data, labels = split_data(mnist["data"], mnist["target"].astype(int), n_data)
     return data, labels, None, "MNIST"
 
+
+def _load_mnist(reshape_to_28x28=False):
+    (x_train, y_train), (x_test, y_test) = load_mnist_data()
+    if reshape_to_28x28:
+        x_train = x_train.reshape((-1, 28, 28))
+        x_test = x_test.reshape((-1, 28, 28))
+    return x_train, y_train, x_test, y_test
 
 def load_fashion(n_data=70000):
     mnist = fetch_openml("Fashion-MNIST")

--- a/dpemu/dataset_utils.py
+++ b/dpemu/dataset_utils.py
@@ -33,8 +33,6 @@ from sklearn.model_selection import train_test_split
 
 from dpemu.utils import get_project_root
 
-warnings.simplefilter(action='ignore', category=FutureWarning)
-from keras.datasets.mnist import load_data as load_mnist_data
 
 random_state = RandomState(42)
 
@@ -87,11 +85,15 @@ def load_mnist(n_data=70000):
 
 
 def _load_mnist(reshape_to_28x28=False):
+    warnings.simplefilter(action='ignore', category=FutureWarning)
+    from keras.datasets.mnist import load_data as load_mnist_data
+
     (x_train, y_train), (x_test, y_test) = load_mnist_data()
     if not reshape_to_28x28:
         x_train = x_train.reshape((-1, 28*28))
         x_test = x_test.reshape((-1, 28*28))
     return x_train, y_train, x_test, y_test
+
 
 def load_fashion(n_data=70000):
     mnist = fetch_openml("Fashion-MNIST")

--- a/dpemu/utils.py
+++ b/dpemu/utils.py
@@ -56,6 +56,18 @@ def get_project_root():
     return Path(__file__).resolve().parents[1]
 
 
+def get_data_dir():
+    """[Get the path to ]
+
+    [extended_summary]
+
+    Returns:
+        [type]: [description]
+    """
+    root_dir = get_project_root()
+    return root_dir / "data"
+
+
 def split_df_by_model(df):
     """[summary]
 

--- a/examples/filter_examples/run_gaussian_noise_and_missing_data_example.py
+++ b/examples/filter_examples/run_gaussian_noise_and_missing_data_example.py
@@ -26,15 +26,16 @@ import numpy as np
 import matplotlib.pyplot as plt
 from dpemu.nodes import Array, TupleSeries
 from dpemu.filters.common import GaussianNoise, Missing
+from dpemu.dataset_utils import _load_mnist
 
 std = float(sys.argv[1])
 prob = float(sys.argv[2])
 
 n = 1000
-x_file = Path("data/mnist_subset/x.npy")
-y_file = Path("data/mnist_subset/y.npy")
-x = np.load(x_file)[:n].reshape((n, 28, 28))
-y = np.load(y_file)[:n]
+x, y, _, _ = _load_mnist(reshape_to_28x28=True)
+x = x[:n].astype('float')
+y = y[:n]
+print(x.min(), x.max())
 
 x_node = Array()
 x_node.addfilter(GaussianNoise("mean", "std"))

--- a/examples/filter_examples/run_gaussian_noise_and_missing_data_example.py
+++ b/examples/filter_examples/run_gaussian_noise_and_missing_data_example.py
@@ -21,7 +21,6 @@
 # SOFTWARE.
 
 import sys
-from pathlib import Path
 import numpy as np
 import matplotlib.pyplot as plt
 from dpemu.nodes import Array, TupleSeries


### PR DESCRIPTION
- the path of the dpEmu/data directory can be obtained by calling get_data_dir()
- the MNIST dataset can be loaded using the new and much faster _get_mnist function which utilizes the corresponding function in Keras
- the gaussian_noise_and_missing_data example now uses _get_mnist() instead of relying on the "mnist_subset" data files